### PR TITLE
Examples of OnPreExecute

### DIFF
--- a/CustomAdhocReports/CustomAdhocReports/CustomAdhocReports.cs
+++ b/CustomAdhocReports/CustomAdhocReports/CustomAdhocReports.cs
@@ -13,11 +13,25 @@ namespace CustomAdhocReports
     [Export(typeof(IAdHocExtension))]
     class CustomAdhocReports : DefaultAdHocExtension
     {
+        /// <summary>
+        /// Adds custom formats for a specified data type.
+        /// </summary>
         public override List<DataFormat> LoadCustomDataFormat()
         {
             return CustomDataFormat.LoadCustomDataFormat();
         }
 
+        /// <summary>
+        /// Customizes the report content on the fly before it is executed.
+        /// </summary>
+        public override ReportDefinition OnPreExecute(ReportDefinition reportDefinition)
+        {
+            return CustomReportDefinition.OnPreExecute(reportDefinition);
+        }
+
+        /// <summary>
+        /// Sets custom filters which are hidden to the user of the interface.
+        /// </summary>
         public override ReportFilterSetting SetHiddenFilters(SetHiddenFilterParam param)
         {
             var filterFieldName = "ShipCountry";

--- a/CustomAdhocReports/CustomAdhocReports/CustomAdhocReports.csproj
+++ b/CustomAdhocReports/CustomAdhocReports/CustomAdhocReports.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="CustomAdhocReports.cs" />
     <Compile Include="CustomDataFormat.cs" />
+    <Compile Include="CustomReportDefinition.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/CustomAdhocReports/CustomAdhocReports/CustomReportDefinition.cs
+++ b/CustomAdhocReports/CustomAdhocReports/CustomReportDefinition.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+using Izenda.BI.Framework.Models.ReportDesigner;
+using Izenda.BI.Framework.Constants;
+
+namespace CustomAdhocReports
+{
+    /// <summary>
+    /// The custom report definition class.
+    /// </summary>
+    static class CustomReportDefinition
+    {
+        /// <summary>
+        /// Customizes the report definition before it is executed.
+        /// </summary>
+        /// <param name="reportDefinition">The report definition to be customized.</param>
+        /// <returns>Returns the customized report definition.</returns>
+        public static ReportDefinition OnPreExecute(ReportDefinition reportDefinition)
+        {
+            // Updates a filter's alias and changes the operator to filter on.
+            const string filterToBeCustomized = "CustomerID";
+            foreach (var filter in reportDefinition.ReportFilter.FilterFields.Where(f => f.Alias == filterToBeCustomized))
+            {
+                filter.Alias = "Customized-Id";
+                filter.OperatorId = Guid.Parse("5CE630BC-6615-42C4-B11E-1D09C651EAAE");
+                filter.OperatorName = "Equals (Checkbox)";
+            }
+
+            // Updates a column's name/alias
+            const string columnToBeCustomized = "ContactName";
+            foreach (var reportPart in reportDefinition.ReportPart.Select(f => f.ReportPartContent))
+            {
+                if (reportPart.GetAllFields().Any(f => f.FieldNameAlias == columnToBeCustomized))
+                {
+                    var filteredFieldsWithColumn = reportPart.GetAllFields().Where(f => f.FieldNameAlias == columnToBeCustomized).ToList();
+                    filteredFieldsWithColumn.ForEach(f => f.FieldNameAlias = "Customized-Name");
+                }
+            }
+
+            // Removes all report parts that are a map
+            if (reportDefinition.ReportPart.Any(x => x.ReportPartContent.Type == ReportPartContentType.Map))
+            {
+                var filteredReportPart = reportDefinition.ReportPart.Where(x => x.ReportPartContent.Type != ReportPartContentType.Map).ToList();
+                reportDefinition.ReportPart = filteredReportPart;
+            }
+
+            return reportDefinition;
+        }
+    }
+}


### PR DESCRIPTION
Case 3424: Added examples of OnPreExecute to the IAdHocExtension implementation. Examples include customizing filters, updating a column name/alias, and filtering report parts based on their type.