### PR TITLE
Fix hidden filter issue caused by joins

### DIFF
--- a/CustomAdhocReports/CustomAdhocReports/CustomAdhocReports.cs
+++ b/CustomAdhocReports/CustomAdhocReports/CustomAdhocReports.cs
@@ -78,10 +78,6 @@ namespace CustomAdhocReports
                 {
                     result.Logic = logic;
                 }
-                else
-                {
-                    result.Logic += $" AND {logic}";
-                }
 
                 return filterPosition;
             };


### PR DESCRIPTION
Resolve hidden filter issue caused by fix to IZ-19668. We are now applying the WHERE clause within the inner query when JOINING two data sources. This was already fixed in the MVC Kit:
https://github.com/Izenda7Series/Mvc5StarterKit/commit/b5c90285c28e8db72cc9105c39006c2175e8174a